### PR TITLE
Feature as set keeping order

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsSet.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsSet.java
@@ -20,7 +20,6 @@ import com.orientechnologies.common.util.OSizeable;
 import com.orientechnologies.orient.core.command.OCommandContext;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.record.impl.ODocument;
-
 import java.util.*;
 
 /**

--- a/core/src/main/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsSet.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsSet.java
@@ -20,11 +20,8 @@ import com.orientechnologies.common.util.OSizeable;
 import com.orientechnologies.orient.core.command.OCommandContext;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.record.impl.ODocument;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+
+import java.util.*;
 
 /**
  * Transforms current value in a Set.
@@ -60,7 +57,7 @@ public class OSQLMethodAsSet extends OAbstractSQLMethod {
     }
 
     if (ioResult instanceof Collection<?>) {
-      return new HashSet<Object>((Collection<Object>) ioResult);
+      return new LinkedHashSet<Object>((Collection<Object>) ioResult);
     } else if (!(ioResult instanceof ODocument) && ioResult instanceof Iterable<?>) {
       ioResult = ((Iterable<?>) ioResult).iterator();
     }
@@ -68,9 +65,9 @@ public class OSQLMethodAsSet extends OAbstractSQLMethod {
     if (ioResult instanceof Iterator<?>) {
       final Set<Object> set;
       if (ioResult instanceof OSizeable) {
-        set = new HashSet<Object>(((OSizeable) ioResult).size());
+        set = new LinkedHashSet<Object>(((OSizeable) ioResult).size());
       } else {
-        set = new HashSet<Object>();
+        set = new LinkedHashSet<Object>();
       }
 
       for (Iterator<Object> iter = (Iterator<Object>) ioResult; iter.hasNext(); ) {

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsSetTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsSetTest.java
@@ -3,8 +3,12 @@ package com.orientechnologies.orient.core.sql.method.misc;
 import static org.junit.Assert.assertEquals;
 
 import com.orientechnologies.orient.core.record.impl.ODocument;
-import java.util.ArrayList;
-import java.util.HashSet;
+
+import java.util.*;
+import java.util.stream.IntStream;
+
+import jnr.ffi.annotations.In;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -114,4 +118,24 @@ public class OSQLMethodAsSetTest {
     expected.add(new Integer(4));
     assertEquals(result, expected);
   }
+
+  @Test
+  public void testIterableOrder() {
+
+    var values = new ArrayList<Integer>(IntStream.rangeClosed(0, 1000)
+        .boxed().toList());
+    Random rnd = new Random();
+    var seed = System.currentTimeMillis();
+    rnd.setSeed(seed);
+    System.out.println(seed);
+    Collections.shuffle(values, rnd);
+
+    TestIterable<Integer> anIterable = new TestIterable<>(values);
+    Object result = function.execute(null, null, null, anIterable, null);
+
+    Assert.assertTrue(result instanceof Set<?>);
+    Assert.assertEquals(values, ((Set<?>) result).stream().toList());
+  }
+
+
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsSetTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsSetTest.java
@@ -3,11 +3,8 @@ package com.orientechnologies.orient.core.sql.method.misc;
 import static org.junit.Assert.assertEquals;
 
 import com.orientechnologies.orient.core.record.impl.ODocument;
-
 import java.util.*;
 import java.util.stream.IntStream;
-
-import jnr.ffi.annotations.In;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -122,8 +119,7 @@ public class OSQLMethodAsSetTest {
   @Test
   public void testIterableOrder() {
 
-    var values = new ArrayList<Integer>(IntStream.rangeClosed(0, 1000)
-        .boxed().toList());
+    var values = new ArrayList<Integer>(IntStream.rangeClosed(0, 1000).boxed().toList());
     Random rnd = new Random();
     var seed = System.currentTimeMillis();
     rnd.setSeed(seed);
@@ -136,6 +132,4 @@ public class OSQLMethodAsSetTest {
     Assert.assertTrue(result instanceof Set<?>);
     Assert.assertEquals(values, ((Set<?>) result).stream().toList());
   }
-
-
 }


### PR DESCRIPTION
What does this PR do?
Used LinkedSet for asSet function

Motivation
If we use distinct for some query we want order to be preserved

Related issues
A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

Additional Notes
Anything else we should know when reviewing?

Checklist
[] I have run the build using `mvn clean package` command
[] My unit tests cover both failure and success scenarios
