### PR TITLE
Expand keeps order when executed over ordered set

### DIFF
--- a/core/src/main/java/com/orientechnologies/orient/core/sql/executor/OResultInternal.java
+++ b/core/src/main/java/com/orientechnologies/orient/core/sql/executor/OResultInternal.java
@@ -18,16 +18,9 @@ import com.orientechnologies.orient.core.record.impl.ODocumentInternal;
 import com.orientechnologies.orient.core.record.impl.OElementInternal;
 import com.orientechnologies.orient.core.serialization.OSerializableStream;
 import java.io.Serializable;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /**
@@ -249,7 +242,12 @@ public class OResultInternal implements OResult {
         return ((List) input).stream().map(OResultInternal::wrap).collect(Collectors.toList());
       } else {
         if (isEmbeddedSet(input)) {
-          return ((Set) input).stream().map(OResultInternal::wrap).collect(Collectors.toSet());
+          Stream mappedSet = ((Set) input).stream().map(OResultInternal::wrap);
+          if (input instanceof LinkedHashSet<?>) {
+            return mappedSet.collect(Collectors.toCollection(LinkedHashSet::new));
+          } else {
+            return mappedSet.collect(Collectors.toSet());
+          }
         } else {
           if (isEmbeddedMap(input)) {
             Map result = new HashMap();

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/executor/OSelectStatementExecutionTest.java
@@ -7,6 +7,7 @@ import com.orientechnologies.common.concur.OTimeoutException;
 import com.orientechnologies.orient.core.command.OCommandContext;
 import com.orientechnologies.orient.core.config.OGlobalConfiguration;
 import com.orientechnologies.orient.core.db.ODatabaseSession;
+import com.orientechnologies.orient.core.db.document.ODatabaseDocument;
 import com.orientechnologies.orient.core.db.record.OIdentifiable;
 import com.orientechnologies.orient.core.db.viewmanager.ViewCreationListener;
 import com.orientechnologies.orient.core.exception.OCommandExecutionException;
@@ -18,6 +19,7 @@ import com.orientechnologies.orient.core.metadata.schema.OSchema;
 import com.orientechnologies.orient.core.metadata.schema.OType;
 import com.orientechnologies.orient.core.metadata.schema.OViewConfig;
 import com.orientechnologies.orient.core.record.OElement;
+import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.OVertex;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.core.sql.OSQLEngine;
@@ -34,6 +36,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.stream.Stream;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -4598,5 +4601,88 @@ public class OSelectStatementExecutionTest extends BaseMemoryDatabase {
       Assert.assertEquals((long) item.getProperty("count"), 1L);
       Assert.assertFalse(rs.hasNext());
     }
+  }
+
+  @Test
+  public void testAsSetKeepsOrderWithExpand() {
+    // init classes
+    db.activateOnCurrentThread();
+    ODatabaseDocument ses = ODatabaseSession.getActiveSession();
+    var car = ses.createVertexClass("Car");
+    var engine = ses.createVertexClass("Engine");
+    var body = ses.createVertexClass("BodyType");
+    var eng = ses.createEdgeClass("eng");
+    var bt = ses.createEdgeClass("bt");
+    ses.begin();
+
+    var diesel = ses.newVertex(engine);
+    diesel.setProperty("name", "diesel");
+    var gasoline = ses.newVertex(engine);
+    gasoline.setProperty("name", "gasoline");
+    var microwave = ses.newVertex(engine);
+    microwave.setProperty("name", "EV");
+
+    var coupe = ses.newVertex(body);
+    coupe.setProperty("name", "coupe");
+    var suv = ses.newVertex(body);
+    suv.setProperty("name", "suv");
+    ses.commit();
+    ses.begin();
+    // fill data
+    var coupe1 = ses.newVertex(car);
+    coupe1.setProperty("name", "car1");
+    coupe1.addEdge(gasoline, eng);
+    coupe1.addEdge(coupe, bt);
+    coupe1.save();
+
+    var coupe2 = ses.newVertex(car);
+    coupe2.setProperty("name", "car2");
+    coupe2.addEdge(diesel, eng);
+    coupe2.addEdge(coupe, bt);
+    coupe2.save();
+
+    var mw1 = ses.newVertex(car);
+    mw1.setProperty("name", "microwave1");
+    mw1.addEdge(microwave, eng);
+    mw1.addEdge(suv, bt);
+    mw1.save();
+
+    var mw2 = ses.newVertex(car);
+    mw2.setProperty("name", "microwave2");
+    mw2.addEdge(microwave, eng);
+    mw2.addEdge(suv, bt);
+    mw2.save();
+
+    var hatch1 = ses.newVertex(car);
+    hatch1.setProperty("name", "hatch1");
+    hatch1.addEdge(diesel, eng);
+    hatch1.addEdge(suv, bt);
+    hatch1.save();
+    ses.commit();
+
+    var identities =
+        String.join(
+            ",",
+            Stream.of(coupe1, coupe2, mw1, mw2, hatch1)
+                .map(ORecord::getIdentity)
+                .map(Object::toString)
+                .toList());
+    var unionAllEnginesQuery =
+        "SELECT expand(unionAll($a, $a).asSet()) LET $a=(SELECT expand(out('eng')) FROM ["
+            + identities
+            + "])";
+
+    var engineNames =
+        db.query(unionAllEnginesQuery)
+            .vertexStream()
+            .map(oVertex -> oVertex.getProperty("name"))
+            .toArray();
+    Assert.assertArrayEquals(
+        Arrays.asList(
+                gasoline.getProperty("name"),
+                diesel.getProperty("name"),
+                microwave.getProperty("name"))
+            .toArray(),
+        engineNames);
   }
 }

--- a/core/src/test/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsSetTest.java
+++ b/core/src/test/java/com/orientechnologies/orient/core/sql/method/misc/OSQLMethodAsSetTest.java
@@ -57,6 +57,7 @@ public class OSQLMethodAsSetTest {
     assertEquals(result, expected);
   }
 
+  @Test
   public void testIterable() {
     // The expected behavior is to return a set with all of the elements
     // of the iterable in it.
@@ -74,6 +75,7 @@ public class OSQLMethodAsSetTest {
     assertEquals(result, expected);
   }
 
+  @Test
   public void testIterator() {
     // The expected behavior is to return a set with all of the elements
     // of the iterator in it.
@@ -91,6 +93,7 @@ public class OSQLMethodAsSetTest {
     assertEquals(result, expected);
   }
 
+  @Test
   public void testODocument() {
     // The expected behavior is to return a set with only the single
     // ODocument in it.
@@ -106,13 +109,14 @@ public class OSQLMethodAsSetTest {
     assertEquals(result, expected);
   }
 
+  @Test
   public void testOtherSingleValue() {
     // The expected behavior is to return a set with only the single
     // element in it.
 
-    Object result = function.execute(null, null, null, new Integer(4), null);
+    Object result = function.execute(null, null, null, 4, null);
     HashSet<Object> expected = new HashSet<Object>();
-    expected.add(new Integer(4));
+    expected.add(4);
     assertEquals(result, expected);
   }
 


### PR DESCRIPTION
What does this PR do?
Check if set is linked before wrapping it. So ordered collection will retain it's order after expand call

Motivation
What inspired you to submit this pull request?

Related issues
A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

Additional Notes
Anything else we should know when reviewing?

Checklist
[] I have run the build using `mvn clean package` command
[] My unit tests cover both failure and success scenarios
